### PR TITLE
Parser for Siconia and Globalsat LS11*P

### DIFF
--- a/globalsat_indoor_air_quality.ex
+++ b/globalsat_indoor_air_quality.ex
@@ -1,0 +1,45 @@
+defmodule Parser do
+  use Platform.Parsing.Behaviour
+  
+  #Parser for globalsat indoor climate monitor
+  #Author F. Wolf fw@alpha-omega-technology.de
+
+  def parse(<<type::big-8, temp::signed-big-16, humid::big-16, sens::big-16>>, _meta) do
+  
+  sensor = case type do
+    1 -> "CO2"
+    2 -> "CO"
+    3 -> "PM 2.5"
+    _ -> "unknown"
+  end
+  
+  %{
+    temperature: temp/100,
+    humidity: humid/100,
+    sens: sens,
+    type: sensor,
+  }
+  end 
+  
+
+   
+  def fields do
+    [
+      %{
+        "field" => "humidity",
+        "display" => "rel. Luftfeuchte",
+        "unit" => "%"
+      },
+      %{
+        "field" => "temperature",
+        "display" => "Temperature",
+        "unit" => "°C"
+      },
+      %{
+        "field" => "sens",
+        "display" => "Concentration",
+        "unit" => "ppm"
+      },
+    ]
+  end
+end

--- a/lib/globalsat_indoor_air_quality(LS11*P).ex
+++ b/lib/globalsat_indoor_air_quality(LS11*P).ex
@@ -1,7 +1,8 @@
 defmodule Parser do
   use Platform.Parsing.Behaviour
   
-  #Parser for globalsat indoor climate monitor
+  #Parser for globalsat indoor climate monitor LS11*P
+  #works for CO, CO2 and PM2.5 Models
   #Author F. Wolf fw@alpha-omega-technology.de
 
   def parse(<<type::big-8, temp::signed-big-16, humid::big-16, sens::big-16>>, _meta) do

--- a/lib/globalsat_indoor_air_quality.ex
+++ b/lib/globalsat_indoor_air_quality.ex
@@ -1,0 +1,45 @@
+defmodule Parser do
+  use Platform.Parsing.Behaviour
+  
+  #Parser for globalsat indoor climate monitor
+  #Author F. Wolf fw@alpha-omega-technology.de
+
+  def parse(<<type::big-8, temp::signed-big-16, humid::big-16, sens::big-16>>, _meta) do
+  
+  %{
+    temperature: temp/100,
+    humidity: humid/100,
+    sens: sens,
+    type: type,
+  }
+  end 
+  
+  cond do
+    type == 1  -> 
+      sensor = "CO2"
+    type == 2  -> 
+      sensor = "CO"
+    type == 3  -> 
+      sensor = "PM 2.5"
+  end
+   
+  def fields do
+    [
+      %{
+        "field" => "humidity",
+        "display" => "rel. Luftfeuchte",
+        "unit" => "%"
+      },
+      %{
+        "field" => "temperature",
+        "display" => "Temperature",
+        "unit" => "°C"
+      },
+      %{
+        "field" => "sens",
+        "display" => sensor,
+        "unit" => "ppm"
+      },
+    ]
+  end
+end


### PR DESCRIPTION
Added parsers for Siconia standard programming and globalsat air quality sensors. Both parsers have been tested and work fine.